### PR TITLE
Impl ring based communication

### DIFF
--- a/ring_flash_attn/comm.py
+++ b/ring_flash_attn/comm.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import torch
 import torch.distributed as dist
 
-__all__ = ['send_recv_kv', 'update_out_and_lse']
+__all__ = ['send_recv_kv', 'update_out_and_lse', 'RingComm']
 
 
 def update_out_and_lse(out: Optional[torch.Tensor], lse: Optional[torch.Tensor],
@@ -32,6 +32,47 @@ def update_out_and_lse(out: Optional[torch.Tensor], lse: Optional[torch.Tensor],
         else:
             lse = new_lse
     return out, lse
+
+
+class RingComm:
+    def __init__(self, process_group: dist.ProcessGroup):
+        self._process_group = process_group
+        self._ops = []
+        self.rank = dist.get_rank(self._process_group)
+        self.world_size = dist.get_world_size(self._process_group)
+        self._reqs = None
+
+    def send_recv(self, to_send: torch.Tensor,
+                  send_direction="incr", inplace=False) -> torch.Tensor:
+        if inplace:
+            res = to_send
+        else:
+            res = torch.empty_like(to_send)
+        if send_direction == "incr":
+            send_rank = (self.rank + 1) % self.world_size
+            recv_rank = (self.rank - 1) % self.world_size
+        else:
+            send_rank = (self.rank - 1) % self.world_size
+            recv_rank = (self.rank + 1) % self.world_size
+
+        send_op = dist.P2POp(dist.isend, to_send, send_rank, group=self._process_group)
+        recv_op = dist.P2POp(dist.irecv, res, recv_rank, group=self._process_group)
+        self._ops.append(send_op)
+        self._ops.append(recv_op)
+        return res
+
+    def commit(self):
+        if self._reqs is not None:
+            raise RuntimeError("commit called twice")
+        self._reqs = dist.batch_isend_irecv(self._ops)
+
+    def wait(self):
+        if self._reqs is None:
+            raise RuntimeError("wait called before commit")
+        for req in self._reqs:
+            req.wait()
+        self._reqs = None
+        self._ops = []
 
 
 def send_recv_kv(process_group, local_k, local_v, step, causal, is_grad=False):

--- a/ring_flash_attn/ring_flash_attn_qkvpacked_2.py
+++ b/ring_flash_attn/ring_flash_attn_qkvpacked_2.py
@@ -1,0 +1,208 @@
+import torch
+import torch.distributed as dist
+from flash_attn.flash_attn_interface import _flash_attn_forward, _flash_attn_backward
+from .comm import RingComm, update_out_and_lse
+
+
+def ring_flash_attn_forward_2(
+        process_group,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        softmax_scale,
+        dropout_p=0,
+        causal=True,
+        window_size=(-1, -1),
+        alibi_slopes=None,
+        deterministic=False,
+):
+    comm = RingComm(process_group)
+
+    out = None
+    lse = None
+
+    for step in range(comm.world_size):
+        if step + 1 != comm.world_size:
+            next_k: torch.Tensor = comm.send_recv(k)
+            next_v: torch.Tensor = comm.send_recv(v)
+            comm.commit()
+
+        if not causal or comm.rank <= step:
+            block_out, _, _, _, _, block_lse, _, _ = _flash_attn_forward(
+                q,
+                k,
+                v,
+                dropout_p,
+                softmax_scale,
+                causal=causal,
+                window_size=window_size,
+                alibi_slopes=alibi_slopes,
+                return_softmax=True and dropout_p > 0,
+            )
+            block_out = block_out.to(torch.float32)
+            block_lse = block_lse.transpose(1, 2).unsqueeze(dim=-1)
+            out, lse = update_out_and_lse(out, lse, block_out, block_lse)
+
+        if step + 1 != comm.world_size:
+            comm.wait()
+            k = next_k
+            v = next_v
+
+    return out, lse
+
+
+def ring_flash_attn_backward_2(
+        process_group,
+        dout,
+        q,
+        k,
+        v,
+        out,
+        softmax_lse,
+        softmax_scale,
+        dropout_p=0,
+        causal=True,
+        window_size=(-1, -1),
+        alibi_slopes=None,
+        deterministic=False,
+):
+    kv_comm = RingComm(process_group)
+    d_kv_comm = RingComm(process_group)
+    dq, dk, dv = None, None, None
+    send_recv_kwargs = {"send_direction": "decr"}
+    next_dk, next_dv = None, None
+
+    for step in range(kv_comm.world_size):
+        if step + 1 != kv_comm.world_size:
+            next_k = kv_comm.send_recv(k, **send_recv_kwargs)
+            next_v = kv_comm.send_recv(v, **send_recv_kwargs)
+            kv_comm.commit()
+
+        if kv_comm.rank <= step or not causal:
+            block_dq, block_dk, block_dv = _flash_attn_backward(
+                dout,
+                q,
+                k,
+                v,
+                out,
+                softmax_lse,
+                softmax_scale,
+                dropout_p,
+                causal,
+                window_size,
+                alibi_slopes,
+                deterministic,
+            )
+            if dq is None:
+                dq = block_dq
+                dk = block_dk
+                dv = block_dv
+            else:
+                dq += block_dq
+                d_kv_comm.wait()
+                dk = next_dk + block_dk
+                dv = next_dv + block_dv
+
+        if step + 1 != kv_comm.world_size:
+            kv_comm.wait()
+            k = next_k
+            v = next_v
+
+        next_dk = d_kv_comm.send_recv(dk, **send_recv_kwargs)
+        next_dv = d_kv_comm.send_recv(dv, **send_recv_kwargs)
+        d_kv_comm.commit()
+
+    d_kv_comm.wait()
+
+    return dq, next_dk, next_dv
+
+
+class RingFlashAttnQKVPackedFuncV2(torch.autograd.Function):
+    @staticmethod
+    def forward(
+            ctx,
+            qkv,
+            dropout_p,
+            softmax_scale,
+            causal,
+            window_size,
+            alibi_slopes,
+            deterministic,
+            return_softmax,
+            group,
+    ):
+        if softmax_scale is None:
+            softmax_scale = qkv.shape[-1] ** (-0.5)
+
+        assert alibi_slopes is None
+        q = qkv[:, :, 0].contiguous()
+        k = qkv[:, :, 1].contiguous()
+        v = qkv[:, :, 2].contiguous()
+        out, softmax_lse = ring_flash_attn_forward_2(
+            group,
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            dropout_p=dropout_p,
+            causal=causal,
+            window_size=window_size,
+            alibi_slopes=alibi_slopes,
+            deterministic=False,
+        )
+        # this should be out_padded
+        ctx.save_for_backward(q, k, v, out, softmax_lse)
+        ctx.dropout_p = dropout_p
+        ctx.softmax_scale = softmax_scale
+        ctx.causal = causal
+        ctx.window_size = window_size
+        ctx.alibi_slopes = alibi_slopes
+        ctx.deterministic = deterministic
+        ctx.group = group
+        return out if not return_softmax else (out, softmax_lse, None)
+
+    @staticmethod
+    def backward(ctx, dout, *args):
+        q, k, v, out, softmax_lse = ctx.saved_tensors
+        dq, dk, dv = ring_flash_attn_backward_2(
+            ctx.group,
+            dout,
+            q,
+            k,
+            v,
+            out,
+            softmax_lse,
+            softmax_scale=ctx.softmax_scale,
+            dropout_p=ctx.dropout_p,
+            causal=ctx.causal,
+            window_size=ctx.window_size,
+            alibi_slopes=ctx.alibi_slopes,
+            deterministic=ctx.deterministic,
+        )
+        dqkv = torch.stack([dq, dk, dv], dim=2)
+        dqkv = dqkv[..., : dout.shape[-1]]  # We could have padded the head dimension
+        return dqkv, None, None, None, None, None, None, None, None
+
+
+def ring_flash_attn_qkvpacked_func_v2(
+        qkv,
+        dropout_p=0.0,
+        softmax_scale=None,
+        causal=False,
+        window_size=(-1, -1),  # -1 means infinite context window
+        alibi_slopes=None,
+        deterministic=False,
+        return_attn_probs=False,
+        group=None,
+):
+    return RingFlashAttnQKVPackedFuncV2.apply(
+        qkv,
+        dropout_p,
+        softmax_scale,
+        causal,
+        window_size,
+        alibi_slopes,
+        deterministic,
+        return_attn_probs,
+        group,
+    )

--- a/test_qkvpacked_func.py
+++ b/test_qkvpacked_func.py
@@ -1,7 +1,10 @@
+import os
+
 from flash_attn import flash_attn_qkvpacked_func
 import torch
 import torch.distributed as dist
 from ring_flash_attn import ring_flash_attn_qkvpacked_func
+from ring_flash_attn.ring_flash_attn_qkvpacked_2 import ring_flash_attn_qkvpacked_func_v2
 
 
 def log(msg, a, rank0_only=False):
@@ -79,7 +82,9 @@ if __name__ == "__main__":
     local_out = out.chunk(world_size, dim=1)[rank]
     local_lse = lse.chunk(world_size, dim=-1)[rank]
 
-    ring_out, ring_lse, _ = ring_flash_attn_qkvpacked_func(
+    fn = ring_flash_attn_qkvpacked_func_v2 if os.getenv("TEST_V2", "OFF") == "ON" else ring_flash_attn_qkvpacked_func
+
+    ring_out, ring_lse, _ = fn(
         local_qkv,
         dropout_p=dropout_p,
         causal=causal,


### PR DESCRIPTION
The original implementation in [ring_flash_attn_qkvpacked.py](https://github.com/zhuzilin/ring-flash-attention/blob/main/test_qkvpacked_func.py) is not ring-based communication. It is more like a for-loop between [node 0] -> [node 1,2,3,4...]. 

The original implementation might be faster by reducing unnecessary communication when `casual`. But,

1. The number of communication rounds in the previous scheme is consistent with that of ring communication. It's just that the previous communication was not balanced.
2. If the network environment is not point-to-point with equal network speed. For example, when involving multiple machines and multiple network cards, ring communication may involve multiple network cards and require the establishment of multiple rings.

Currently, this implementation is just a proof of concept implementation and just established one ring. 

It need more careful design to implement a proper ring based attention later.