### PR TITLE
fix exp overflow when updating lse

### DIFF
--- a/ring_flash_attn/utils.py
+++ b/ring_flash_attn/utils.py
@@ -2,9 +2,9 @@ from typing import Optional, Tuple
 
 import torch
 import torch.distributed as dist
-_logSigmoid = torch.nn.LogSigmoid()
-__all__ = ["update_out_and_lse", "RingComm"]
+import torch.nn.functional as F
 
+__all__ = ["update_out_and_lse", "RingComm"]
 
 @torch.jit.script
 def _update_out_and_lse(
@@ -17,7 +17,7 @@ def _update_out_and_lse(
     block_lse = block_lse.transpose(-2, -1).unsqueeze(dim=-1)
 
     #new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
-    new_lse = lse - _logSigmoid(lse - block_lse)
+    new_lse = lse - F.logsigmoid(lse - block_lse)
     out = torch.exp(lse - new_lse) * out + torch.exp(block_lse - new_lse) * block_out
 
     lse = new_lse

--- a/ring_flash_attn/utils.py
+++ b/ring_flash_attn/utils.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import torch
 import torch.distributed as dist
-
+_logSigmoid = torch.nn.LogSigmoid()
 __all__ = ["update_out_and_lse", "RingComm"]
 
 
@@ -16,8 +16,8 @@ def _update_out_and_lse(
     block_out = block_out.to(torch.float32)
     block_lse = block_lse.transpose(-2, -1).unsqueeze(dim=-1)
 
-    new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
-
+    #new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
+    new_lse = lse - _logSigmoid(lse - block_lse)
     out = torch.exp(lse - new_lse) * out + torch.exp(block_lse - new_lse) * block_out
 
     lse = new_lse


### PR DESCRIPTION
Fix the exp overflow when updating LSE
------------------
    #new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
    new_lse = lse - _logSigmoid(lse - block_lse)