### PR TITLE
remove unnecessary dtype casts in _update_out_and_lse function

### DIFF
--- a/ring_flash_attn/utils.py
+++ b/ring_flash_attn/utils.py
@@ -13,7 +13,7 @@ def _update_out_and_lse(
     block_out: torch.Tensor,
     block_lse: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    block_out = block_out.to(torch.float32)
+
     block_lse = block_lse.transpose(-2, -1).unsqueeze(dim=-1)
 
     #new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))


### PR DESCRIPTION
It seems unnecessary to cast block_out from bf16 to fp32.