### PR TITLE
Fix llama3 when torch compile with capturing scalar outputs

### DIFF
--- a/ring_flash_attn/llama3_flash_attn_varlen.py
+++ b/ring_flash_attn/llama3_flash_attn_varlen.py
@@ -21,11 +21,12 @@ def llama3_flash_attn_prepare_cu_seqlens(
         local_k_slice: slice, the slice of the k that the local q need. Note
             that this may be longer than `total_seq_len // world_size`.
     """
-    total_length = cu_seqlens[-1].item()
+    total_length = cu_seqlens[-1]
     assert total_length % world_size == 0
     length_per_rank = total_length // world_size
     left = torch.searchsorted(cu_seqlens, rank * length_per_rank)
     right = torch.searchsorted(cu_seqlens, (rank + 1) * length_per_rank)
+    length_per_rank = length_per_rank.item()
 
     # after this, cu_seqlens[left:right + 1] contains all the sequence for this rank
     if cu_seqlens[left] != rank * length_per_rank:


### PR DESCRIPTION
Without this workaround, it will throw an error: "Could not extract specialized integer from data-dependent expression"

This is caused by the `torch.searchsorted` in `llama3_flash_attn_prepare_cu_seqlens`, the total length is dependent on the last element in `cu_seqlens`. If we convert the tensor to scalar with `.item()` here, it will create a situation similar to https://github.com/pytorch/pytorch/issues/150613

This workaround resolves this by delaying the tensor to scalar conversion after `torch.searchsorted` finishes. This is OK as the second param `values` of `torch.searchsorted` also accept the tensor type.
https://pytorch.org/docs/stable/generated/torch.searchsorted.html