### PR TITLE
add new signature for updated hf transformers

### DIFF
--- a/ring_flash_attn/adapters/hf_adapter.py
+++ b/ring_flash_attn/adapters/hf_adapter.py
@@ -232,10 +232,50 @@ def create_ring_flash_attention_forward(
             deterministic,
         )
 
+    # transformers 4.53.0+
+    def _flash_attention_forward_v3(
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        query_length: int,
+        is_causal: bool,
+        dropout: float = 0.0,
+        position_ids: Optional[torch.Tensor] = None,
+        softmax_scale: Optional[float] = None,
+        sliding_window: Optional[int] = None,
+        use_top_left_mask: bool = False,
+        softcap: Optional[float] = None,
+        deterministic: bool = None,
+        cu_seq_lens_q: Optional[torch.LongTensor] = None,
+        cu_seq_lens_k: Optional[torch.LongTensor] = None,
+        max_length_q: Optional[int] = None,
+        max_length_k: Optional[int] = None,
+        target_dtype: Optional[torch.dtype] = None,
+        attn_implementation: Optional[str] = None,
+        **kwargs,
+    ):
+        return _flash_attention_forward(
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            query_length,
+            is_causal,
+            dropout,
+            position_ids,
+            softmax_scale,
+            sliding_window,
+            use_top_left_mask,
+            softcap,
+            deterministic,
+        )
+
     return [
         _flash_attention_forward,
         _flash_attention_forward_v1,
         _flash_attention_forward_v2,
+        _flash_attention_forward_v3,
     ]
 
 


### PR DESCRIPTION
Upstream API change [here]( https://github.com/huggingface/transformers/pull/38972/files#diff-3535cab7d42ed303a48ba7935efb93624809f59d669ba270fed99568e8d0b0aa) breaks ring-flash-attn. Hopefully a patch release can go out with this change? 🙏 