### PR TITLE
use updated var from hf refactor

### DIFF
--- a/ring_flash_attn/adapters/hf_adapter.py
+++ b/ring_flash_attn/adapters/hf_adapter.py
@@ -6,10 +6,18 @@ import torch
 import torch.distributed as dist
 import transformers
 import transformers.modeling_flash_attention_utils
-from transformers.modeling_flash_attention_utils import (
-    _flash_supports_window_size,
-    is_flash_attn_greater_or_equal,
-)
+try:
+    from transformers.modeling_flash_attention_utils import (
+        _flash_supports_window,
+        is_flash_attn_greater_or_equal,
+    )
+except ImportError:
+    # transformers <= 4.53.x
+    from transformers.modeling_flash_attention_utils import (
+        _flash_supports_window_size as _flash_supports_window,
+        is_flash_attn_greater_or_equal,
+    )
+
 from ..llama3_flash_attn_varlen import (
     llama3_flash_attn_varlen_func,
     llama3_flash_attn_prepare_cu_seqlens,
@@ -111,7 +119,7 @@ def create_ring_flash_attention_forward(
 
         # Assuming 4D tensors, key_states.shape[1] is the key/value sequence length (source length).
         use_sliding_windows = (
-            _flash_supports_window_size
+            _flash_supports_window
             and sliding_window is not None
             and key_states.shape[1] > sliding_window
         )


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/39474 refactored the `_flash_supports_window_size` variable name

we had to do a similar fix in https://github.com/axolotl-ai-cloud/axolotl/pull/2966, but we still import ring-flash-attn, so we need this change as well to use latest transformers.