### PR TITLE
i think it's a bug when computing max_seqlen_list

### DIFF
--- a/benchmark/benchmark_varlen_kvpacked_func.py
+++ b/benchmark/benchmark_varlen_kvpacked_func.py
@@ -86,7 +86,7 @@ def benchmark(
             local_k_slice_list.append(local_k_slice)
     else:
         max_seqlen_list = [
-            (cu_seqlens[1:] - cu_seqlens[:1]).max().item()
+            (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
             for cu_seqlens in cu_seqlens_list
         ]
 


### PR DESCRIPTION
as you write in /test/test_ring_flash_attn_varlen_func.py line 50:  max_seqlen = (cu_seqlens_tensor[1:] - cu_seqlens_tensor[:**-1**]).max().item()
i think "/benchmark/benchmark_varlen_kvpacked_func.py line 89  (cu_seqlens[1:] - cu_seqlens[:1])"  is a bug